### PR TITLE
Vim Options

### DIFF
--- a/crates/command_palette_hooks/src/command_palette_hooks.rs
+++ b/crates/command_palette_hooks/src/command_palette_hooks.rs
@@ -108,7 +108,7 @@ pub struct CommandInterceptResult {
 /// An interceptor for the command palette.
 #[derive(Default)]
 pub struct CommandPaletteInterceptor(
-    Option<Box<dyn Fn(&str, &App) -> Option<CommandInterceptResult>>>,
+    Option<Box<dyn Fn(&str, &App) -> Vec<CommandInterceptResult>>>,
 );
 
 #[derive(Default)]
@@ -132,10 +132,12 @@ impl CommandPaletteInterceptor {
     }
 
     /// Intercepts the given query from the command palette.
-    pub fn intercept(&self, query: &str, cx: &App) -> Option<CommandInterceptResult> {
-        let handler = self.0.as_ref()?;
-
-        (handler)(query, cx)
+    pub fn intercept(&self, query: &str, cx: &App) -> Vec<CommandInterceptResult> {
+        if let Some(handler) = self.0.as_ref() {
+            (handler)(query, cx)
+        } else {
+            Vec::new()
+        }
     }
 
     /// Clears the global interceptor.
@@ -146,7 +148,7 @@ impl CommandPaletteInterceptor {
     /// Sets the global interceptor.
     ///
     /// This will override the previous interceptor, if it exists.
-    pub fn set(&mut self, handler: Box<dyn Fn(&str, &App) -> Option<CommandInterceptResult>>) {
+    pub fn set(&mut self, handler: Box<dyn Fn(&str, &App) -> Vec<CommandInterceptResult>>) {
         self.0 = Some(handler);
     }
 }

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -935,7 +935,7 @@ pub fn command_interceptor(mut input: &str, cx: &App) -> Vec<CommandInterceptRes
             .boxed_clone(),
         )
     } else if query.starts_with("se ") || query.starts_with("set ") {
-        return VimOption::possible_commands(query.splitn(2, " ").skip(1).next().unwrap());
+        return VimOption::possible_commands(query.split_once(" ").unwrap().1);
     } else if query.starts_with('s') {
         let mut substitute = "substitute".chars().peekable();
         let mut query = query.chars().peekable();

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -69,6 +69,10 @@ pub struct WithCount {
 pub enum VimSetting {
     Wrap,
     NoWrap,
+    Number,
+    NoNumber,
+    RelativeNumber,
+    NoRelativeNumber,
 }
 
 #[derive(Debug)]
@@ -116,6 +120,18 @@ pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
             }
             VimSetting::NoWrap => {
                 editor.set_soft_wrap_mode(language::language_settings::SoftWrap::None, cx);
+            }
+            VimSetting::Number => {
+                editor.set_show_line_numbers(true, cx);
+            }
+            VimSetting::NoNumber => {
+                editor.set_show_line_numbers(false, cx);
+            }
+            VimSetting::RelativeNumber => {
+                editor.set_relative_line_number(Some(true), cx);
+            }
+            VimSetting::NoRelativeNumber => {
+                editor.set_relative_line_number(Some(false), cx);
             }
         });
     });
@@ -770,6 +786,12 @@ fn generate_commands(_: &App) -> Vec<VimCommand> {
         VimCommand::new(("cpp", "link"), editor::actions::CopyPermalinkToLine).range(act_on_range),
         VimCommand::new(("set wrap", ""), VimSetting::Wrap),
         VimCommand::new(("set nowrap", ""), VimSetting::NoWrap),
+        VimCommand::new(("set nu", "mber"), VimSetting::Number),
+        VimCommand::new(("set nonu", "mber"), VimSetting::NoNumber),
+        VimCommand::new(("set rnu", ""), VimSetting::RelativeNumber),
+        VimCommand::new(("set relativenumber", ""), VimSetting::RelativeNumber),
+        VimCommand::new(("set nornu", ""), VimSetting::NoRelativeNumber),
+        VimCommand::new(("set norelativenumber", ""), VimSetting::NoRelativeNumber),
     ]
 }
 


### PR DESCRIPTION
Supports a `:set` option that takes a space separated list of predefined options.

Outstanding questions:

1. I'm not sure about the other options, and how we'd assess feasibility to options to add.
2. It is not possible in Zed to have `:set nonu rnu`. Disabling line numbers also hides relative numbers. Separate bug?
3. I'm not sure if this logic deserves to be extracted into its own file.
4. There seems to be some overlap (and at least naming collision) with the `VimSettings` struct defined in `vim.rs`. This seems like it declares config settings for that, but the `toggle_relative_line_numbers` seems like it would interact with the line number options I've declared here. Maybe a reason to leave them out?
5. I thought that Vim did parsing in between things like `nu` and `number`, but it doesn't. Typing `:set numb` will not actually work, so I've just hardcoded the short options. However, Vim also has autocomplete for these things, which we don't have here. My gut is that it's out of scope for this change, along with command history and suchlike.